### PR TITLE
Add comprehensive Rust tutorial with runnable examples

### DIFF
--- a/rust/RUST_PROGRAMMING_TUTORIAL.md
+++ b/rust/RUST_PROGRAMMING_TUTORIAL.md
@@ -1,0 +1,688 @@
+# Rust Programming Tutorial (Easy → Medium → Hard → Brutal)
+
+This tutorial is organized by difficulty and designed to be practical:
+
+- Every concept includes prerequisites, an explanation, a **self-sufficient code example**, best practices, and common pitfalls.
+- Installation steps are included first.
+- The examples are mirrored in `tests/rust_tutorial_examples.rs` and validated with:
+
+```bash
+cargo test --test rust_tutorial_examples
+```
+
+---
+
+## 0) Rust Installation
+
+### Linux / macOS / WSL
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+rustc --version
+cargo --version
+```
+
+### Windows (PowerShell)
+
+```powershell
+winget install Rustlang.Rustup
+rustc --version
+cargo --version
+```
+
+### Keep Tooling Updated
+
+```bash
+rustup update
+rustup component add rustfmt clippy
+```
+
+### Create and Run a Project
+
+```bash
+cargo new hello-rust
+cd hello-rust
+cargo run
+```
+
+---
+
+## 1) EASY
+
+### 1.1 Variables, Mutability, and Shadowing
+
+**Prerequisites:** Rust installed, terminal access.
+
+```rust
+fn main() {
+    let x = 2;
+    let x = x + 3; // shadowing
+    let mut y = 10;
+    y += x;
+    println!("x={x}, y={y}");
+}
+```
+
+**Best practices**
+- Default to immutable (`let`) and only use `mut` when needed.
+- Use shadowing to transform values while keeping names meaningful.
+
+**Pitfalls**
+- Confusing shadowing (`let x = ...`) with mutation (`x = ...`).
+
+---
+
+### 1.2 Scalar/Compound Types and Control Flow
+
+**Prerequisites:** Variables and `if` statements.
+
+```rust
+fn main() {
+    let numbers = [1, 2, 3, 4, 5];
+    let mut sum = 0;
+    for n in numbers {
+        sum += n;
+    }
+    let label = if sum > 10 { "big" } else { "small" };
+    println!("sum={sum}, label={label}");
+}
+```
+
+**Best practices**
+- Prefer iterator-based loops for transformations.
+- Keep conditionals expression-oriented (`if` returns values).
+
+**Pitfalls**
+- Mixing integer types (`i32`, `u32`, `usize`) without explicit conversion.
+
+---
+
+### 1.3 Ownership, Borrowing, and Slices
+
+**Prerequisites:** `String`, references (`&T`), functions.
+
+```rust
+fn first_word(s: &str) -> &str {
+    s.split_whitespace().next().unwrap_or("")
+}
+
+fn main() {
+    let original = String::from("hello rust");
+    let borrowed = &original; // borrow, no move
+    let cloned = original.clone(); // deep copy
+
+    println!("borrowed={borrowed}");
+    println!("first word={}", first_word(&cloned));
+}
+```
+
+**Best practices**
+- Use `&str` for read-only string parameters.
+- Clone only when ownership transfer is truly needed.
+
+**Pitfalls**
+- Moving a value and then trying to use it again.
+- Holding mutable and immutable references at the same time.
+
+---
+
+### 1.4 Structs, Enums, and Pattern Matching
+
+**Prerequisites:** Basic data types and `match`.
+
+```rust
+struct User {
+    name: String,
+    active: bool,
+}
+
+enum Command {
+    Start,
+    Stop,
+}
+
+fn main() {
+    let user = User {
+        name: "Ari".to_string(),
+        active: true,
+    };
+    let command = Command::Start;
+
+    let action = match command {
+        Command::Start if user.active => format!("{} started", user.name),
+        Command::Start => "inactive user".to_string(),
+        Command::Stop => "stopped".to_string(),
+    };
+    println!("{action}");
+}
+```
+
+**Best practices**
+- Model state with enums instead of booleans when there are multiple states.
+- Use `match` guards for precise logic.
+
+**Pitfalls**
+- Using `if/else` chains where enum-based `match` is safer and clearer.
+
+---
+
+### 1.5 Modules, Collections, Option, and Result
+
+**Prerequisites:** Functions and pattern matching.
+
+```rust
+mod math {
+    pub fn add(a: i32, b: i32) -> i32 {
+        a + b
+    }
+}
+
+fn parse_port(input: &str) -> Result<u16, String> {
+    let port = input.parse::<u16>().map_err(|e| e.to_string())?;
+    if port == 0 {
+        return Err("port must be > 0".to_string());
+    }
+    Ok(port)
+}
+
+fn main() {
+    let mut values = vec![3, 1, 2];
+    values.sort();
+    println!("sum={}", math::add(20, 22));
+    println!("sorted={values:?}");
+    println!("port={:?}", parse_port("8080"));
+}
+```
+
+**Best practices**
+- Return `Result<T, E>` for fallible operations.
+- Keep module APIs small and explicit with `pub`.
+
+**Pitfalls**
+- Calling `.unwrap()` in production paths instead of handling errors.
+
+---
+
+## 2) MEDIUM
+
+### 2.1 Generics, Traits, and Lifetimes
+
+**Prerequisites:** Structs, enums, references.
+
+```rust
+trait Summarize {
+    fn summary(&self) -> String;
+}
+
+struct Article {
+    title: String,
+    author: String,
+}
+
+impl Summarize for Article {
+    fn summary(&self) -> String {
+        format!("{} by {}", self.title, self.author)
+    }
+}
+
+fn longest<'a>(left: &'a str, right: &'a str) -> &'a str {
+    if left.len() >= right.len() { left } else { right }
+}
+
+fn print_summary<T: Summarize>(item: &T) {
+    println!("{}", item.summary());
+}
+
+fn main() {
+    let article = Article {
+        title: "Rust Patterns".to_string(),
+        author: "Niko".to_string(),
+    };
+    print_summary(&article);
+    println!("longest={}", longest("ownership", "borrow"));
+}
+```
+
+**Best practices**
+- Use trait bounds to express behavior requirements.
+- Add explicit lifetimes only when elision rules are insufficient.
+
+**Pitfalls**
+- Treating lifetimes as runtime duration (they are compile-time relationships).
+
+---
+
+### 2.2 Iterators and Closures
+
+**Prerequisites:** Vectors, functions.
+
+```rust
+fn main() {
+    let values = vec![1, 2, 3, 4, 5, 6];
+    let even_squares: Vec<i32> = values
+        .into_iter()
+        .filter(|n| n % 2 == 0)
+        .map(|n| n * n)
+        .collect();
+
+    println!("{even_squares:?}");
+}
+```
+
+**Best practices**
+- Favor iterator chains over index-based loops when transforming data.
+- Know ownership behavior: `iter()` (borrow), `iter_mut()` (mutable borrow), `into_iter()` (move).
+
+**Pitfalls**
+- Unexpected moves after calling `into_iter()`.
+
+---
+
+### 2.3 Custom Errors and `?` Propagation
+
+**Prerequisites:** `Result`, enums, traits.
+
+```rust
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+enum AppError {
+    EmptyInput,
+    Parse(std::num::ParseIntError),
+}
+
+impl fmt::Display for AppError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AppError::EmptyInput => write!(f, "input was empty"),
+            AppError::Parse(e) => write!(f, "parse error: {e}"),
+        }
+    }
+}
+
+impl Error for AppError {}
+
+fn parse_nonzero(input: &str) -> Result<u32, AppError> {
+    if input.trim().is_empty() {
+        return Err(AppError::EmptyInput);
+    }
+    let value: u32 = input.parse().map_err(AppError::Parse)?;
+    if value == 0 {
+        return Err(AppError::EmptyInput);
+    }
+    Ok(value)
+}
+
+fn main() {
+    println!("{:?}", parse_nonzero("7"));
+}
+```
+
+**Best practices**
+- Use domain-specific error enums.
+- Preserve source errors when mapping.
+
+**Pitfalls**
+- Losing diagnostics by replacing all errors with a generic string too early.
+
+---
+
+### 2.4 Testing, Tooling, and Conditional Compilation
+
+**Prerequisites:** Cargo basics.
+
+```rust
+#[cfg(debug_assertions)]
+fn build_mode() -> &'static str { "debug" }
+
+#[cfg(not(debug_assertions))]
+fn build_mode() -> &'static str { "release" }
+
+fn main() {
+    println!("mode={}", build_mode());
+}
+```
+
+**Best practices**
+- Run `cargo fmt`, `cargo clippy`, and `cargo test` frequently.
+- Use `#[cfg(...)]` for platform/build-mode specific code.
+
+**Pitfalls**
+- Hiding logic behind cfg flags without testing both code paths.
+
+---
+
+## 3) HARD
+
+### 3.1 Smart Pointers (`Box`, `Rc`, `RefCell`)
+
+**Prerequisites:** Ownership and borrowing.
+
+```rust
+use std::cell::RefCell;
+use std::rc::Rc;
+
+fn main() {
+    let shared = Rc::new(RefCell::new(String::from("hi")));
+    let a = Rc::clone(&shared);
+    let b = Rc::clone(&shared);
+
+    a.borrow_mut().push_str(" rust");
+    b.borrow_mut().push('!');
+
+    println!("{}", shared.borrow());
+}
+```
+
+**Best practices**
+- Use `Rc<T>` for shared ownership in single-threaded contexts.
+- Use `RefCell<T>` only when compile-time borrowing is too restrictive.
+
+**Pitfalls**
+- Runtime panics from violating `RefCell` borrow rules.
+- Using `Rc<T>` across threads (use `Arc<T>` instead).
+
+---
+
+### 3.2 Concurrency with Threads, Channels, and `Arc<Mutex<T>>`
+
+**Prerequisites:** Closures (`move`) and ownership transfer.
+
+```rust
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+
+fn main() {
+    let (tx, rx) = mpsc::channel();
+    let counter = Arc::new(Mutex::new(0usize));
+    let mut handles = Vec::new();
+
+    for id in 0..4 {
+        let tx = tx.clone();
+        let counter = Arc::clone(&counter);
+        handles.push(thread::spawn(move || {
+            *counter.lock().unwrap() += 1;
+            tx.send(id * 2).unwrap();
+        }));
+    }
+    drop(tx);
+
+    let mut received: Vec<_> = rx.iter().collect();
+    received.sort_unstable();
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    println!("received={received:?}");
+    println!("counter={}", *counter.lock().unwrap());
+}
+```
+
+**Best practices**
+- Keep lock scope as small as possible.
+- Prefer message passing for ownership transfer across threads.
+
+**Pitfalls**
+- Holding mutex guards too long.
+- Deadlocks from lock ordering issues.
+
+---
+
+### 3.3 Async/Await Fundamentals (Self-Contained Executor)
+
+**Prerequisites:** Futures and trait basics.
+
+```rust
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::thread;
+
+fn noop_waker() -> Waker {
+    fn clone(_: *const ()) -> RawWaker { RawWaker::new(std::ptr::null(), &VTABLE) }
+    fn noop(_: *const ()) {}
+    static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
+    unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut future = Box::pin(future);
+    loop {
+        match Future::poll(Pin::as_mut(&mut future), &mut cx) {
+            Poll::Ready(v) => return v,
+            Poll::Pending => thread::yield_now(),
+        }
+    }
+}
+
+async fn async_add(left: i32, right: i32) -> i32 { left + right }
+
+fn main() {
+    let answer = block_on(async_add(20, 22));
+    println!("{answer}");
+}
+```
+
+**Best practices**
+- In real services, use mature runtimes (`tokio`, `async-std`) rather than a toy executor.
+
+**Pitfalls**
+- Blocking threads inside async code.
+
+---
+
+### 3.4 Macros and Trait Objects
+
+**Prerequisites:** Traits, generics, and pattern matching.
+
+```rust
+macro_rules! pair_vec {
+    ($($key:expr => $value:expr),* $(,)?) => {{
+        let mut tmp = Vec::new();
+        $( tmp.push(($key, $value)); )*
+        tmp
+    }};
+}
+
+trait Shape {
+    fn area(&self) -> f64;
+}
+
+struct Rectangle {
+    width: f64,
+    height: f64,
+}
+
+impl Shape for Rectangle {
+    fn area(&self) -> f64 {
+        self.width * self.height
+    }
+}
+
+fn main() {
+    let pairs = pair_vec!("rust" => 1, "cargo" => 2);
+    let shapes: Vec<Box<dyn Shape>> = vec![Box::new(Rectangle { width: 3.0, height: 4.0 })];
+    println!("{pairs:?} area={}", shapes[0].area());
+}
+```
+
+**Best practices**
+- Use trait objects (`dyn Trait`) for runtime polymorphism.
+- Keep macro interfaces small and predictable.
+
+**Pitfalls**
+- Overusing macros where functions/generics are clearer.
+
+---
+
+## 4) BRUTAL
+
+### 4.1 Unsafe Rust and FFI
+
+**Prerequisites:** Pointers, linking basics, ownership model.
+
+```rust
+unsafe extern "C" {
+    fn abs(input: i32) -> i32;
+}
+
+fn main() {
+    let mut value = 41;
+    let ptr = &mut value as *mut i32;
+    unsafe { *ptr += 1; }
+    println!("value={value}");
+
+    let absolute = unsafe { abs(-42) };
+    println!("abs={absolute}");
+}
+```
+
+**Best practices**
+- Keep `unsafe` blocks tiny and heavily justified.
+- Wrap unsafe internals behind safe APIs.
+
+**Pitfalls**
+- Dereferencing invalid pointers.
+- Violating aliasing or lifetime assumptions.
+
+---
+
+### 4.2 Atomics and Memory Ordering
+
+**Prerequisites:** Threading and shared state.
+
+```rust
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+
+fn main() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let mut handles = Vec::new();
+
+    for _ in 0..8 {
+        let counter = Arc::clone(&counter);
+        handles.push(thread::spawn(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }));
+    }
+
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    println!("counter={}", counter.load(Ordering::SeqCst));
+}
+```
+
+**Best practices**
+- Start with `SeqCst`; relax orderings only with clear proof/benchmark motivation.
+
+**Pitfalls**
+- Incorrect memory ordering assumptions that produce rare race bugs.
+
+---
+
+### 4.3 Const Generics and Compile-Time Configuration
+
+**Prerequisites:** Generics and arrays.
+
+```rust
+#[derive(Debug)]
+struct RingBuffer<const N: usize> {
+    data: [u8; N],
+    write_index: usize,
+}
+
+impl<const N: usize> RingBuffer<N> {
+    fn new() -> Self {
+        Self { data: [0; N], write_index: 0 }
+    }
+
+    fn push(&mut self, byte: u8) {
+        self.data[self.write_index % N] = byte;
+        self.write_index += 1;
+    }
+}
+
+fn main() {
+    let mut rb = RingBuffer::<4>::new();
+    rb.push(10);
+    rb.push(20);
+    rb.push(30);
+    rb.push(40);
+    rb.push(50);
+    println!("{:?}", rb.data); // [50, 20, 30, 40]
+}
+```
+
+**Best practices**
+- Use const generics to encode fixed-size constraints in types.
+
+**Pitfalls**
+- Over-parameterizing APIs and making error messages hard to read.
+
+---
+
+## 5) Language Feature Coverage Checklist
+
+This tutorial covers:
+
+- Ownership, borrowing, references, slices
+- Primitive and compound types
+- Control flow and pattern matching
+- Structs, enums, methods, modules, visibility
+- Collections (`Vec`, `String`) and iterators
+- `Option`, `Result`, custom errors, `?`
+- Generics, traits, trait bounds, trait objects
+- Lifetimes
+- Closures and iterator adapters
+- Testing/tooling (`cargo test`, `fmt`, `clippy`)
+- Conditional compilation (`cfg`)
+- Smart pointers (`Box`, `Rc`, `RefCell`, `Arc`, `Mutex`)
+- Concurrency (threads, channels)
+- Async/await fundamentals
+- Declarative macros (`macro_rules!`)
+- Unsafe Rust basics
+- FFI (`extern "C"`)
+- Atomics and memory ordering
+- Const generics
+
+---
+
+## 6) Recommended Best Practices (Global)
+
+1. Prefer safe Rust; isolate `unsafe`.
+2. Keep ownership simple and explicit.
+3. Design small types with clear invariants.
+4. Return `Result` instead of panicking in library code.
+5. Run `cargo fmt`, `cargo clippy`, and `cargo test` in CI.
+6. Benchmark before optimizing (`cargo bench`, `cargo flamegraph` where applicable).
+7. Document assumptions and edge cases in API docs.
+
+---
+
+## 7) Common Pitfalls (Global)
+
+1. Overusing `.unwrap()` and `.expect()` in non-test code.
+2. Cloning too much to bypass ownership issues.
+3. Choosing `Rc<RefCell<T>>` when plain borrowing would work.
+4. Holding mutex guards across expensive operations.
+5. Prematurely using advanced atomics/unsafe without necessity.
+6. Confusing trait-object dynamic dispatch with generic static dispatch.
+
+---
+
+## 8) How to Validate the Examples
+
+From this repository root:
+
+```bash
+cargo test --test rust_tutorial_examples
+```
+
+That command compiles and runs the tutorial-backed examples end-to-end.

--- a/rust/docs/rust-features/README.md
+++ b/rust/docs/rust-features/README.md
@@ -1,0 +1,60 @@
+# Rust Features Tutorial (Split by Concept)
+
+This is the split version of the Rust tutorial: one Markdown file per concept/feature, organized by difficulty.
+
+- **Easy**: foundational syntax and core ownership model
+- **Medium**: abstraction, error architecture, and tooling discipline
+- **Hard**: advanced runtime patterns and language power features
+- **Brutal**: low-level systems topics where correctness pressure is highest
+
+All code examples are self-contained (each can live in its own `main.rs`), and representative examples are validated in:
+
+```bash
+cargo test --test rust_tutorial_examples
+```
+
+---
+
+## Easy
+
+1. [`00_rust_installation.md`](./easy/00_rust_installation.md)
+2. [`01_variables_mutability_shadowing.md`](./easy/01_variables_mutability_shadowing.md)
+3. [`02_types_control_flow.md`](./easy/02_types_control_flow.md)
+4. [`03_ownership_borrowing_slices.md`](./easy/03_ownership_borrowing_slices.md)
+5. [`04_structs_enums_pattern_matching.md`](./easy/04_structs_enums_pattern_matching.md)
+6. [`05_modules_collections_option_result.md`](./easy/05_modules_collections_option_result.md)
+
+## Medium
+
+1. [`01_generics_traits_lifetimes.md`](./medium/01_generics_traits_lifetimes.md)
+2. [`02_iterators_closures.md`](./medium/02_iterators_closures.md)
+3. [`03_custom_errors_question_mark.md`](./medium/03_custom_errors_question_mark.md)
+4. [`04_testing_tooling_cfg.md`](./medium/04_testing_tooling_cfg.md)
+
+## Hard
+
+1. [`01_smart_pointers.md`](./hard/01_smart_pointers.md)
+2. [`02_concurrency_threads_channels_mutex.md`](./hard/02_concurrency_threads_channels_mutex.md)
+3. [`03_async_await.md`](./hard/03_async_await.md)
+4. [`04_macros.md`](./hard/04_macros.md)
+5. [`05_trait_objects.md`](./hard/05_trait_objects.md)
+
+## Brutal
+
+1. [`01_unsafe_rust.md`](./brutal/01_unsafe_rust.md)
+2. [`02_ffi.md`](./brutal/02_ffi.md)
+3. [`03_atomics_memory_ordering.md`](./brutal/03_atomics_memory_ordering.md)
+4. [`04_const_generics.md`](./brutal/04_const_generics.md)
+
+---
+
+## Installation (Quick)
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+rustup update
+rustup component add rustfmt clippy
+rustc --version
+cargo --version
+```

--- a/rust/docs/rust-features/brutal/01_unsafe_rust.md
+++ b/rust/docs/rust-features/brutal/01_unsafe_rust.md
@@ -1,0 +1,42 @@
+# Brutal: Unsafe Rust
+
+## What this feature is
+
+Unsafe Rust is an escape hatch that allows operations the compiler cannot prove safe, such as dereferencing raw pointers, calling unsafe functions, and accessing mutable statics.
+
+Important: `unsafe` does **not** disable borrowing rules globally. It only permits specific operations inside explicit blocks.
+
+## Prerequisites
+
+- Strong ownership and borrowing understanding
+- Pointer fundamentals
+
+## Self-contained example
+
+```rust
+fn main() {
+    let mut value = 41;
+    let ptr = &mut value as *mut i32;
+
+    unsafe {
+        // SAFETY:
+        // ptr comes from a valid mutable reference to `value`
+        // and is used while `value` is still alive.
+        *ptr += 1;
+    }
+
+    println!("value={value}");
+}
+```
+
+## Best practices
+
+- Keep unsafe blocks as small as possible.
+- Document safety invariants right above each unsafe use.
+- Wrap unsafe internals behind safe APIs when possible.
+
+## Pitfalls
+
+- Creating dangling pointers.
+- Violating aliasing assumptions (`&mut` uniqueness).
+- Using unsafe for performance guesses without profiling.

--- a/rust/docs/rust-features/brutal/02_ffi.md
+++ b/rust/docs/rust-features/brutal/02_ffi.md
@@ -1,0 +1,41 @@
+# Brutal: FFI (Foreign Function Interface)
+
+## What this feature is
+
+FFI lets Rust call functions from other languages (commonly C) and expose Rust functions to external code. This is critical for system integration, legacy interop, and low-level runtime hooks.
+
+Rust uses `extern "C"` to define ABI compatibility with C.
+
+## Prerequisites
+
+- Unsafe Rust basics
+- Linking and C ABI awareness
+
+## Self-contained example
+
+```rust
+unsafe extern "C" {
+    fn abs(input: i32) -> i32;
+}
+
+fn main() {
+    let value = -42;
+    let absolute = unsafe {
+        // SAFETY:
+        // `abs` is provided by the C standard library and accepts i32-compatible int.
+        abs(value)
+    };
+    println!("abs({value}) = {absolute}");
+}
+```
+
+## Best practices
+
+- Keep ABI boundaries narrow and well-documented.
+- Prefer `#[repr(C)]` for structs shared across FFI boundaries.
+- Validate pointer/nullability assumptions aggressively.
+
+## Pitfalls
+
+- ABI mismatch leading to undefined behavior.
+- Passing Rust-owned memory across FFI without clear ownership contracts.

--- a/rust/docs/rust-features/brutal/03_atomics_memory_ordering.md
+++ b/rust/docs/rust-features/brutal/03_atomics_memory_ordering.md
@@ -1,0 +1,53 @@
+# Brutal: Atomics and Memory Ordering
+
+## What this feature is
+
+Atomics provide lock-free synchronization primitives for shared data. Memory ordering controls visibility and reordering guarantees between threads. Correct ordering is central to writing race-free lock-free code.
+
+Common orderings:
+
+- `SeqCst`: strongest and easiest to reason about
+- `Acquire`/`Release`: paired synchronization for reads/writes
+- `Relaxed`: atomicity only, minimal ordering guarantees
+
+## Prerequisites
+
+- Threading basics
+- Shared-state concurrency concepts
+
+## Self-contained example
+
+```rust
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+
+fn main() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let mut handles = Vec::new();
+
+    for _ in 0..8 {
+        let c = Arc::clone(&counter);
+        handles.push(thread::spawn(move || {
+            c.fetch_add(1, Ordering::SeqCst);
+        }));
+    }
+
+    for h in handles {
+        h.join().expect("thread join failed");
+    }
+
+    println!("counter={}", counter.load(Ordering::SeqCst));
+}
+```
+
+## Best practices
+
+- Start with `SeqCst`; optimize ordering only with evidence.
+- Add comments explaining synchronization intent.
+- Test under stress and use tools like `loom` for concurrency models.
+
+## Pitfalls
+
+- Using `Relaxed` where happens-before guarantees are required.
+- Assuming atomics alone make compound operations logically safe.

--- a/rust/docs/rust-features/brutal/04_const_generics.md
+++ b/rust/docs/rust-features/brutal/04_const_generics.md
@@ -1,0 +1,56 @@
+# Brutal: Const Generics
+
+## What this feature is
+
+Const generics let you parameterize types and functions with compile-time constant values (like array length). This enables APIs that encode structural constraints directly in types.
+
+It is especially powerful for fixed-size buffers, numeric kernels, and protocol encodings.
+
+## Prerequisites
+
+- Generics and structs
+- Arrays and indexing
+
+## Self-contained example
+
+```rust
+#[derive(Debug)]
+struct RingBuffer<const N: usize> {
+    data: [u8; N],
+    write_index: usize,
+}
+
+impl<const N: usize> RingBuffer<N> {
+    fn new() -> Self {
+        Self {
+            data: [0; N],
+            write_index: 0,
+        }
+    }
+
+    fn push(&mut self, byte: u8) {
+        self.data[self.write_index % N] = byte;
+        self.write_index += 1;
+    }
+}
+
+fn main() {
+    let mut rb = RingBuffer::<4>::new();
+    rb.push(10);
+    rb.push(20);
+    rb.push(30);
+    rb.push(40);
+    rb.push(50);
+    println!("{:?}", rb.data); // [50, 20, 30, 40]
+}
+```
+
+## Best practices
+
+- Use const generics when size is part of the domain invariant.
+- Keep API ergonomics in mind; expose sensible defaults where possible.
+
+## Pitfalls
+
+- Overengineering generic parameters and hurting readability.
+- Assuming runtime flexibility where compile-time specialization is required.

--- a/rust/docs/rust-features/easy/00_rust_installation.md
+++ b/rust/docs/rust-features/easy/00_rust_installation.md
@@ -1,0 +1,63 @@
+# Easy: Rust Installation and Environment Setup
+
+## What this feature is
+
+Before learning language features, you need a stable toolchain and standard developer components. Rust uses `rustup` to install/manage compiler channels and related tools.
+
+## Prerequisites
+
+- Internet access
+- Terminal/PowerShell access
+
+## Installation steps
+
+### Linux / macOS / WSL
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+rustc --version
+cargo --version
+```
+
+### Windows (PowerShell)
+
+```powershell
+winget install Rustlang.Rustup
+rustc --version
+cargo --version
+```
+
+### Recommended components
+
+```bash
+rustup update
+rustup component add rustfmt clippy
+```
+
+## Self-contained example
+
+```rust
+fn main() {
+    println!("Rust setup successful!");
+}
+```
+
+Run:
+
+```bash
+cargo new hello-rust
+cd hello-rust
+cargo run
+```
+
+## Best practices
+
+- Keep stable toolchain updated.
+- Enable `rustfmt` and `clippy` in your editor/CI.
+- Pin toolchain in team repos when reproducibility matters.
+
+## Pitfalls
+
+- Mixing toolchains unintentionally across projects.
+- Skipping `rustup update` for long periods.

--- a/rust/docs/rust-features/easy/01_variables_mutability_shadowing.md
+++ b/rust/docs/rust-features/easy/01_variables_mutability_shadowing.md
@@ -1,0 +1,41 @@
+# Easy: Variables, Mutability, and Shadowing
+
+## What this feature is
+
+Rust variables are immutable by default. This design nudges you toward safer code by preventing accidental state changes. When you intentionally need mutation, you opt in with `mut`.
+
+Shadowing lets you reuse the same variable name with a new binding (`let x = ...`). Unlike mutation, shadowing can also change type and is often used to represent staged transformations.
+
+## Prerequisites
+
+- Rust installed (`rustc`, `cargo`)
+- Basic command line usage
+
+## Self-contained example
+
+```rust
+fn main() {
+    let x = 2;
+    let x = x + 3; // shadowed: new immutable binding
+
+    let mut y = 10; // mutable binding
+    y += x;
+
+    let spaces = "   ";
+    let spaces = spaces.len(); // shadowing can change type (&str -> usize)
+
+    println!("x={x}, y={y}, spaces={spaces}");
+}
+```
+
+## Best practices
+
+- Start immutable and upgrade to `mut` only when necessary.
+- Use shadowing to represent transformation steps cleanly.
+- Keep scope small so variables are easy to reason about.
+
+## Pitfalls
+
+- Confusing shadowing with mutation.
+- Overusing `mut`, which can hide logic bugs.
+- Reusing names too aggressively and reducing readability.

--- a/rust/docs/rust-features/easy/02_types_control_flow.md
+++ b/rust/docs/rust-features/easy/02_types_control_flow.md
@@ -1,0 +1,45 @@
+# Easy: Types and Control Flow
+
+## What this feature is
+
+Rust has strong static typing with no implicit numeric conversions. You get compile-time guarantees that significantly reduce runtime surprises.
+
+Control flow (`if`, `match`, `loop`, `while`, `for`) is expression-oriented. For example, `if` returns a value, so branch logic can be concise and type-checked.
+
+## Prerequisites
+
+- Variables and expressions
+- Basic arithmetic
+
+## Self-contained example
+
+```rust
+fn main() {
+    let numbers: [i32; 5] = [1, 2, 3, 4, 5];
+    let mut sum = 0;
+
+    for n in numbers {
+        sum += n;
+    }
+
+    let label = if sum > 10 { "big" } else { "small" };
+
+    let parity = match sum % 2 {
+        0 => "even",
+        _ => "odd",
+    };
+
+    println!("sum={sum}, label={label}, parity={parity}");
+}
+```
+
+## Best practices
+
+- Use explicit types when intent is not obvious.
+- Prefer `match` for exhaustive branching.
+- Treat warnings about type conversions seriously.
+
+## Pitfalls
+
+- Mixing numeric types (`i32`, `u32`, `usize`) without explicit conversion.
+- Forgetting that both `if` branches must resolve to the same type.

--- a/rust/docs/rust-features/easy/03_ownership_borrowing_slices.md
+++ b/rust/docs/rust-features/easy/03_ownership_borrowing_slices.md
@@ -1,0 +1,52 @@
+# Easy: Ownership, Borrowing, and Slices
+
+## What this feature is
+
+Ownership is Rust’s core memory-safety model:
+
+- Every value has one owner.
+- Values are dropped when the owner goes out of scope.
+- Move semantics transfer ownership by default.
+
+Borrowing (`&T`, `&mut T`) lets you access data without taking ownership. Slices (`&str`, `&[T]`) are borrowed views over contiguous memory.
+
+## Prerequisites
+
+- Variables and functions
+- `String` and arrays
+
+## Self-contained example
+
+```rust
+fn first_word(input: &str) -> &str {
+    input.split_whitespace().next().unwrap_or("")
+}
+
+fn append_exclamation(text: &mut String) {
+    text.push('!');
+}
+
+fn main() {
+    let original = String::from("hello rust");
+    let borrowed: &str = &original; // immutable borrow
+    println!("borrowed={borrowed}");
+
+    let mut changed = original.clone(); // clone when separate ownership is needed
+    append_exclamation(&mut changed); // mutable borrow
+
+    println!("first_word={}", first_word(&changed));
+    println!("changed={changed}");
+}
+```
+
+## Best practices
+
+- Accept `&str` in APIs unless ownership is required.
+- Keep mutable borrow scope short.
+- Clone intentionally, not as a reflex.
+
+## Pitfalls
+
+- Using a value after move.
+- Attempting simultaneous mutable and immutable borrows.
+- Returning references to temporary values.

--- a/rust/docs/rust-features/easy/04_structs_enums_pattern_matching.md
+++ b/rust/docs/rust-features/easy/04_structs_enums_pattern_matching.md
@@ -1,0 +1,56 @@
+# Easy: Structs, Enums, and Pattern Matching
+
+## What this feature is
+
+Structs model data with named fields. Enums model a value that can be one of several variants, each potentially carrying data. Together, they create robust domain modeling with compile-time exhaustiveness via `match`.
+
+## Prerequisites
+
+- Functions and basic types
+- Control flow (`if`, `match`)
+
+## Self-contained example
+
+```rust
+#[derive(Debug)]
+struct User {
+    name: String,
+    active: bool,
+}
+
+#[derive(Debug)]
+enum Command {
+    Start { retries: u8 },
+    Stop,
+}
+
+fn handle(user: &User, cmd: Command) -> String {
+    match cmd {
+        Command::Start { retries } if user.active => {
+            format!("{} started with retries={retries}", user.name)
+        }
+        Command::Start { .. } => "inactive user cannot start".to_string(),
+        Command::Stop => "stopped".to_string(),
+    }
+}
+
+fn main() {
+    let user = User {
+        name: "Ari".to_string(),
+        active: true,
+    };
+    println!("{}", handle(&user, Command::Start { retries: 3 }));
+    println!("{}", handle(&user, Command::Stop));
+}
+```
+
+## Best practices
+
+- Use enums to represent finite states/events explicitly.
+- Let `match` force you to handle all cases.
+- Derive `Debug` for fast diagnostics.
+
+## Pitfalls
+
+- Using booleans where an enum would be safer and clearer.
+- Adding wildcard (`_`) arms too early and hiding future missing cases.

--- a/rust/docs/rust-features/easy/05_modules_collections_option_result.md
+++ b/rust/docs/rust-features/easy/05_modules_collections_option_result.md
@@ -1,0 +1,53 @@
+# Easy: Modules, Collections, `Option`, and `Result`
+
+## What this feature is
+
+Modules organize code and control visibility (`pub`). Collections such as `Vec` and `String` are core dynamic data containers. `Option<T>` models optional data; `Result<T, E>` models fallible operations and forces explicit error handling.
+
+## Prerequisites
+
+- Functions and ownership basics
+- Structs/enums basics
+
+## Self-contained example
+
+```rust
+mod math {
+    pub fn add(a: i32, b: i32) -> i32 {
+        a + b
+    }
+}
+
+fn parse_port(input: &str) -> Result<u16, String> {
+    let port = input.parse::<u16>().map_err(|e| e.to_string())?;
+    if port == 0 {
+        return Err("port must be > 0".to_string());
+    }
+    Ok(port)
+}
+
+fn maybe_nth(values: &[i32], idx: usize) -> Option<i32> {
+    values.get(idx).copied()
+}
+
+fn main() {
+    let mut values = vec![3, 1, 2];
+    values.sort();
+
+    println!("sum={}", math::add(20, 22));
+    println!("sorted={values:?}");
+    println!("maybe_nth(10)={:?}", maybe_nth(&values, 10));
+    println!("parse_port(8080)={:?}", parse_port("8080"));
+}
+```
+
+## Best practices
+
+- Keep modules focused by responsibility.
+- Return `Option`/`Result` instead of panicking.
+- Prefer `?` for clear error propagation.
+
+## Pitfalls
+
+- Excessive `unwrap()` in production code.
+- Exposing too much module internals with broad `pub` usage.

--- a/rust/docs/rust-features/hard/01_smart_pointers.md
+++ b/rust/docs/rust-features/hard/01_smart_pointers.md
@@ -1,0 +1,48 @@
+# Hard: Smart Pointers (`Box`, `Rc`, `RefCell`, `Arc`, `Mutex`)
+
+## What this feature is
+
+Smart pointers extend raw ownership with additional semantics:
+
+- `Box<T>`: heap allocation with single ownership
+- `Rc<T>`: reference-counted shared ownership (single-threaded)
+- `RefCell<T>`: runtime-checked interior mutability (single-threaded)
+- `Arc<T>`: atomic reference counting (thread-safe shared ownership)
+- `Mutex<T>`: interior mutability with mutual exclusion across threads
+
+These types are essential when plain borrowing cannot model the ownership graph you need.
+
+## Prerequisites
+
+- Ownership and borrowing
+- Structs and methods
+
+## Self-contained example
+
+```rust
+use std::cell::RefCell;
+use std::rc::Rc;
+
+fn main() {
+    let shared = Rc::new(RefCell::new(String::from("hi")));
+    let a = Rc::clone(&shared);
+    let b = Rc::clone(&shared);
+
+    a.borrow_mut().push_str(" rust");
+    b.borrow_mut().push('!');
+
+    println!("value={}", shared.borrow());
+    println!("strong_count={}", Rc::strong_count(&shared));
+}
+```
+
+## Best practices
+
+- Start with plain references and upgrade only when necessary.
+- Keep `RefCell` borrow scopes narrow to avoid runtime panics.
+- Use `Arc<T>` instead of `Rc<T>` in multi-threaded contexts.
+
+## Pitfalls
+
+- Choosing `Rc<RefCell<T>>` as a default architecture pattern.
+- Forgetting that `RefCell` enforces borrowing at runtime, not compile time.

--- a/rust/docs/rust-features/hard/02_concurrency_threads_channels_mutex.md
+++ b/rust/docs/rust-features/hard/02_concurrency_threads_channels_mutex.md
@@ -1,0 +1,60 @@
+# Hard: Concurrency with Threads, Channels, and `Arc<Mutex<T>>`
+
+## What this feature is
+
+Rust concurrency is based on ownership transfer, borrowing rules, and thread-safe primitives:
+
+- `thread::spawn` to run work in parallel
+- channels (`mpsc`) for message passing
+- `Arc<Mutex<T>>` for shared mutable state across threads
+
+The compiler prevents data races by construction.
+
+## Prerequisites
+
+- Closures (`move`)
+- Ownership transfer semantics
+
+## Self-contained example
+
+```rust
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+
+fn main() {
+    let (tx, rx) = mpsc::channel();
+    let counter = Arc::new(Mutex::new(0usize));
+    let mut handles = Vec::new();
+
+    for id in 0..4 {
+        let tx = tx.clone();
+        let counter = Arc::clone(&counter);
+        handles.push(thread::spawn(move || {
+            *counter.lock().expect("mutex poisoned") += 1;
+            tx.send(id * 2).expect("send failed");
+        }));
+    }
+    drop(tx);
+
+    let mut received: Vec<_> = rx.iter().collect();
+    received.sort_unstable();
+
+    for h in handles {
+        h.join().expect("thread join failed");
+    }
+
+    println!("received={received:?}");
+    println!("counter={}", *counter.lock().expect("mutex poisoned"));
+}
+```
+
+## Best practices
+
+- Prefer message passing to reduce lock complexity.
+- Keep lock hold time as short as possible.
+- Handle poison errors intentionally in production systems.
+
+## Pitfalls
+
+- Deadlocks from inconsistent lock order.
+- Holding locks while doing expensive I/O.

--- a/rust/docs/rust-features/hard/03_async_await.md
+++ b/rust/docs/rust-features/hard/03_async_await.md
@@ -1,0 +1,61 @@
+# Hard: Async/Await Fundamentals
+
+## What this feature is
+
+`async` functions in Rust return futures. A future is a state machine that makes progress when polled by an executor. `await` suspends logically (without blocking the OS thread) until a future is ready.
+
+This model enables high-concurrency I/O systems with predictable overhead.
+
+## Prerequisites
+
+- Traits and generics
+- Basic concurrency concepts
+
+## Self-contained example
+
+```rust
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::thread;
+
+fn noop_waker() -> Waker {
+    fn clone(_: *const ()) -> RawWaker {
+        RawWaker::new(std::ptr::null(), &VTABLE)
+    }
+    fn noop(_: *const ()) {}
+    static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
+    unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut future = Box::pin(future);
+    loop {
+        match Future::poll(Pin::as_mut(&mut future), &mut cx) {
+            Poll::Ready(value) => return value,
+            Poll::Pending => thread::yield_now(),
+        }
+    }
+}
+
+async fn async_add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+fn main() {
+    let value = block_on(async_add(20, 22));
+    println!("value={value}");
+}
+```
+
+## Best practices
+
+- Use battle-tested executors (`tokio`) for real applications.
+- Keep async code non-blocking; move CPU-heavy work to dedicated threads.
+
+## Pitfalls
+
+- Blocking inside async tasks, which harms scheduler fairness.
+- Confusing concurrency (many tasks) with parallelism (many cores).

--- a/rust/docs/rust-features/hard/04_macros.md
+++ b/rust/docs/rust-features/hard/04_macros.md
@@ -1,0 +1,40 @@
+# Hard: Declarative Macros (`macro_rules!`)
+
+## What this feature is
+
+Macros in Rust generate code at compile time. Declarative macros (`macro_rules!`) match token patterns and expand them into Rust code. They are ideal when repeated structure cannot be expressed ergonomically with functions or generics.
+
+## Prerequisites
+
+- Functions and pattern syntax
+- Understanding of expression contexts
+
+## Self-contained example
+
+```rust
+macro_rules! pair_vec {
+    ($($k:expr => $v:expr),* $(,)?) => {{
+        let mut out = Vec::new();
+        $(
+            out.push(($k, $v));
+        )*
+        out
+    }};
+}
+
+fn main() {
+    let pairs = pair_vec!("rust" => 1, "cargo" => 2, "clippy" => 3);
+    println!("{pairs:?}");
+}
+```
+
+## Best practices
+
+- Keep macro input grammar minimal and obvious.
+- Emit readable expansions and good error messages when possible.
+- Prefer functions/generics unless macro power is truly needed.
+
+## Pitfalls
+
+- Overusing macros and making code hard to trace.
+- Hidden side effects inside macro expansions.

--- a/rust/docs/rust-features/hard/05_trait_objects.md
+++ b/rust/docs/rust-features/hard/05_trait_objects.md
@@ -1,0 +1,62 @@
+# Hard: Trait Objects and Dynamic Dispatch
+
+## What this feature is
+
+Trait objects (`dyn Trait`) let you store values of different concrete types behind a common interface. Calls are dynamically dispatched at runtime, which is useful when type sets are open-ended or plugin-like.
+
+This contrasts with generics, which use static dispatch and monomorphization at compile time.
+
+## Prerequisites
+
+- Traits and impl blocks
+- Heap allocation with `Box`
+
+## Self-contained example
+
+```rust
+trait Shape {
+    fn area(&self) -> f64;
+}
+
+struct Rectangle {
+    width: f64,
+    height: f64,
+}
+
+struct Circle {
+    radius: f64,
+}
+
+impl Shape for Rectangle {
+    fn area(&self) -> f64 {
+        self.width * self.height
+    }
+}
+
+impl Shape for Circle {
+    fn area(&self) -> f64 {
+        std::f64::consts::PI * self.radius * self.radius
+    }
+}
+
+fn main() {
+    let shapes: Vec<Box<dyn Shape>> = vec![
+        Box::new(Rectangle { width: 3.0, height: 4.0 }),
+        Box::new(Circle { radius: 2.0 }),
+    ];
+
+    for (idx, s) in shapes.iter().enumerate() {
+        println!("shape#{idx} area={:.2}", s.area());
+    }
+}
+```
+
+## Best practices
+
+- Use generics when the concrete type is known at compile time.
+- Use trait objects for heterogeneous collections and plugin boundaries.
+
+## Pitfalls
+
+- Expecting trait objects to support methods requiring `Self: Sized`.
+- Ignoring dynamic dispatch overhead in ultra-hot paths.

--- a/rust/docs/rust-features/medium/01_generics_traits_lifetimes.md
+++ b/rust/docs/rust-features/medium/01_generics_traits_lifetimes.md
@@ -1,0 +1,59 @@
+# Medium: Generics, Traits, and Lifetimes
+
+## What this feature is
+
+Generics let you write reusable code over multiple types without runtime overhead. Traits define shared behavior contracts. Lifetimes describe how references relate, ensuring no dangling references at compile time.
+
+Together, these features power Rust’s zero-cost abstractions: high-level APIs with low-level performance.
+
+## Prerequisites
+
+- Ownership and borrowing
+- Structs and functions
+
+## Self-contained example
+
+```rust
+trait Summarize {
+    fn summary(&self) -> String;
+}
+
+struct Article {
+    title: String,
+    author: String,
+}
+
+impl Summarize for Article {
+    fn summary(&self) -> String {
+        format!("{} by {}", self.title, self.author)
+    }
+}
+
+fn print_summary<T: Summarize>(item: &T) {
+    println!("{}", item.summary());
+}
+
+fn longest<'a>(left: &'a str, right: &'a str) -> &'a str {
+    if left.len() >= right.len() { left } else { right }
+}
+
+fn main() {
+    let article = Article {
+        title: "Rust Patterns".to_string(),
+        author: "Niko".to_string(),
+    };
+    print_summary(&article);
+    println!("longest={}", longest("ownership", "borrow"));
+}
+```
+
+## Best practices
+
+- Use trait bounds to define capability requirements.
+- Keep lifetime annotations minimal and meaningful.
+- Prefer generic APIs where static dispatch is beneficial.
+
+## Pitfalls
+
+- Treating lifetimes as runtime duration.
+- Over-constraining generics, hurting API ergonomics.

--- a/rust/docs/rust-features/medium/02_iterators_closures.md
+++ b/rust/docs/rust-features/medium/02_iterators_closures.md
@@ -1,0 +1,39 @@
+# Medium: Iterators and Closures
+
+## What this feature is
+
+Iterators are lazy pipelines for processing sequences. Closures are anonymous functions that can capture environment state. Combined, they allow concise, expressive transformations while preserving type safety and performance.
+
+## Prerequisites
+
+- Vectors/collections
+- Basic functions
+
+## Self-contained example
+
+```rust
+fn main() {
+    let values = vec![1, 2, 3, 4, 5, 6];
+
+    let even_squares: Vec<i32> = values
+        .into_iter()        // takes ownership
+        .filter(|n| n % 2 == 0)
+        .map(|n| n * n)
+        .collect();
+
+    println!("{even_squares:?}");
+}
+```
+
+## Best practices
+
+- Prefer iterator chains for transformation-heavy logic.
+- Choose the right iterator flavor:
+  - `iter()` for shared borrow
+  - `iter_mut()` for mutable borrow
+  - `into_iter()` for ownership move
+
+## Pitfalls
+
+- Accidentally moving values with `into_iter()`.
+- Writing overly long chains that become hard to read (split into named steps).

--- a/rust/docs/rust-features/medium/03_custom_errors_question_mark.md
+++ b/rust/docs/rust-features/medium/03_custom_errors_question_mark.md
@@ -1,0 +1,63 @@
+# Medium: Custom Errors and `?` Propagation
+
+## What this feature is
+
+Rust error handling is explicit and type-driven. Instead of exceptions, you return `Result<T, E>`. Creating domain-specific error enums gives callers precise failure reasons and supports structured recovery.
+
+The `?` operator propagates errors ergonomically while preserving static types.
+
+## Prerequisites
+
+- Enums and `Result`
+- Traits (`Debug`, `Display`)
+
+## Self-contained example
+
+```rust
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+enum AppError {
+    EmptyInput,
+    Parse(std::num::ParseIntError),
+}
+
+impl fmt::Display for AppError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AppError::EmptyInput => write!(f, "input was empty"),
+            AppError::Parse(e) => write!(f, "parse error: {e}"),
+        }
+    }
+}
+
+impl Error for AppError {}
+
+fn parse_nonzero(input: &str) -> Result<u32, AppError> {
+    if input.trim().is_empty() {
+        return Err(AppError::EmptyInput);
+    }
+    let value: u32 = input.parse().map_err(AppError::Parse)?;
+    if value == 0 {
+        return Err(AppError::EmptyInput);
+    }
+    Ok(value)
+}
+
+fn main() {
+    println!("{:?}", parse_nonzero("7"));
+    println!("{:?}", parse_nonzero("0"));
+}
+```
+
+## Best practices
+
+- Keep error variants meaningful and actionable.
+- Preserve source error context when converting.
+- Decide where to convert to user-facing strings (usually near boundaries).
+
+## Pitfalls
+
+- Erasing useful context too early.
+- Using panic for expected error paths.

--- a/rust/docs/rust-features/medium/04_testing_tooling_cfg.md
+++ b/rust/docs/rust-features/medium/04_testing_tooling_cfg.md
@@ -1,0 +1,60 @@
+# Medium: Testing, Tooling, and Conditional Compilation
+
+## What this feature is
+
+Rust’s development loop is tightly integrated with Cargo:
+
+- `cargo test` for correctness
+- `cargo fmt` for formatting consistency
+- `cargo clippy` for lint-driven quality improvements
+
+Conditional compilation (`#[cfg(...)]`) lets you compile code only for certain platforms, features, or build modes.
+
+## Prerequisites
+
+- Cargo project basics
+- Functions and modules
+
+## Self-contained example
+
+```rust
+#[cfg(debug_assertions)]
+fn build_mode() -> &'static str {
+    "debug"
+}
+
+#[cfg(not(debug_assertions))]
+fn build_mode() -> &'static str {
+    "release"
+}
+
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+fn main() {
+    println!("mode={}", build_mode());
+    println!("2 + 3 = {}", add(2, 3));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::add;
+
+    #[test]
+    fn adds_numbers() {
+        assert_eq!(add(2, 3), 5);
+    }
+}
+```
+
+## Best practices
+
+- Run `fmt`, `clippy`, and tests before every commit.
+- Gate platform-specific code with `cfg` instead of runtime checks.
+- Keep tests deterministic and isolated.
+
+## Pitfalls
+
+- Forgetting to test both cfg paths.
+- Treating clippy warnings as optional in critical code.

--- a/rust/tests/rust_tutorial_examples.rs
+++ b/rust/tests/rust_tutorial_examples.rs
@@ -1,0 +1,377 @@
+use std::cell::RefCell;
+use std::error::Error;
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::thread;
+
+unsafe extern "C" {
+    fn abs(input: i32) -> i32;
+}
+
+#[test]
+fn easy_variables_and_shadowing() {
+    let x = 2;
+    let x = x + 3;
+    let mut y = 10;
+    y += x;
+
+    assert_eq!(x, 5);
+    assert_eq!(y, 15);
+}
+
+#[test]
+fn easy_types_and_control_flow() {
+    let numbers = [1, 2, 3, 4, 5];
+    let mut sum = 0;
+    for n in numbers {
+        sum += n;
+    }
+
+    let label = if sum > 10 { "big" } else { "small" };
+    assert_eq!(sum, 15);
+    assert_eq!(label, "big");
+}
+
+#[test]
+fn easy_ownership_borrowing_and_slices() {
+    fn first_word(s: &str) -> &str {
+        s.split_whitespace().next().unwrap_or("")
+    }
+
+    let original = String::from("hello rust");
+    let borrowed = &original;
+    let cloned = original.clone();
+
+    assert_eq!(borrowed, "hello rust");
+    assert_eq!(first_word(&cloned), "hello");
+}
+
+#[test]
+fn easy_structs_enums_and_match() {
+    struct User {
+        name: String,
+        active: bool,
+    }
+
+    enum Command {
+        Start,
+        Stop,
+    }
+
+    let user = User {
+        name: "Ari".to_string(),
+        active: true,
+    };
+    let command = Command::Start;
+
+    let action = match command {
+        Command::Start if user.active => format!("{} started", user.name),
+        Command::Start => "inactive user".to_string(),
+        Command::Stop => "stopped".to_string(),
+    };
+
+    assert_eq!(action, "Ari started");
+
+    let stop = Command::Stop;
+    let action = match stop {
+        Command::Start => "started".to_string(),
+        Command::Stop => "stopped".to_string(),
+    };
+    assert_eq!(action, "stopped");
+}
+
+#[test]
+fn easy_modules_collections_and_option_result() {
+    mod math {
+        pub fn add(a: i32, b: i32) -> i32 {
+            a + b
+        }
+    }
+
+    fn parse_port(input: &str) -> Result<u16, String> {
+        let port = input.parse::<u16>().map_err(|e| e.to_string())?;
+        if port == 0 {
+            return Err("port must be > 0".to_string());
+        }
+        Ok(port)
+    }
+
+    let mut values = vec![3, 1, 2];
+    values.sort();
+
+    assert_eq!(math::add(20, 22), 42);
+    assert_eq!(values, vec![1, 2, 3]);
+    assert_eq!(parse_port("8080").ok(), Some(8080));
+    assert!(parse_port("0").is_err());
+    assert!(parse_port("not-a-number").is_err());
+}
+
+trait Summarize {
+    fn summary(&self) -> String;
+}
+
+struct Article {
+    title: String,
+    author: String,
+}
+
+impl Summarize for Article {
+    fn summary(&self) -> String {
+        format!("{} by {}", self.title, self.author)
+    }
+}
+
+fn print_summary<T: Summarize>(item: &T) -> String {
+    item.summary()
+}
+
+#[test]
+fn medium_generics_traits_and_lifetimes() {
+    fn longest<'a>(left: &'a str, right: &'a str) -> &'a str {
+        if left.len() >= right.len() {
+            left
+        } else {
+            right
+        }
+    }
+
+    let article = Article {
+        title: "Rust Patterns".to_string(),
+        author: "Niko".to_string(),
+    };
+
+    assert_eq!(print_summary(&article), "Rust Patterns by Niko");
+    assert_eq!(longest("ownership", "borrow"), "ownership");
+}
+
+#[test]
+fn medium_iterators_and_closures() {
+    let values = vec![1, 2, 3, 4, 5, 6];
+    let even_squares: Vec<i32> = values
+        .into_iter()
+        .filter(|n| n % 2 == 0)
+        .map(|n| n * n)
+        .collect();
+
+    assert_eq!(even_squares, vec![4, 16, 36]);
+}
+
+#[derive(Debug)]
+enum AppError {
+    EmptyInput,
+    Parse(std::num::ParseIntError),
+}
+
+impl fmt::Display for AppError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AppError::EmptyInput => write!(f, "input was empty"),
+            AppError::Parse(e) => write!(f, "parse error: {e}"),
+        }
+    }
+}
+
+impl Error for AppError {}
+
+fn parse_nonzero(input: &str) -> Result<u32, AppError> {
+    if input.trim().is_empty() {
+        return Err(AppError::EmptyInput);
+    }
+    let value: u32 = input.parse().map_err(AppError::Parse)?;
+    if value == 0 {
+        return Err(AppError::EmptyInput);
+    }
+    Ok(value)
+}
+
+#[test]
+fn medium_custom_errors_and_question_mark() {
+    assert_eq!(parse_nonzero("7").ok(), Some(7));
+    assert!(parse_nonzero("0").is_err());
+    assert!(parse_nonzero("x").is_err());
+}
+
+#[test]
+fn hard_smart_pointers_rc_and_refcell() {
+    let shared = Rc::new(RefCell::new(String::from("hi")));
+    let a = Rc::clone(&shared);
+    let b = Rc::clone(&shared);
+
+    a.borrow_mut().push_str(" rust");
+    b.borrow_mut().push('!');
+
+    assert_eq!(shared.borrow().as_str(), "hi rust!");
+    assert_eq!(Rc::strong_count(&shared), 3);
+}
+
+#[test]
+fn hard_threads_channels_and_mutex() {
+    let (tx, rx) = mpsc::channel();
+    let workers = 4;
+    let counter = Arc::new(Mutex::new(0usize));
+    let mut handles = Vec::new();
+
+    for id in 0..workers {
+        let tx = tx.clone();
+        let counter = Arc::clone(&counter);
+        handles.push(thread::spawn(move || {
+            {
+                let mut guard = counter.lock().expect("mutex poisoned");
+                *guard += 1;
+            }
+            tx.send(id * 2).expect("send failed");
+        }));
+    }
+    drop(tx);
+
+    let mut received: Vec<_> = rx.iter().collect();
+    received.sort_unstable();
+
+    for handle in handles {
+        handle.join().expect("thread join failed");
+    }
+
+    assert_eq!(received, vec![0, 2, 4, 6]);
+    assert_eq!(*counter.lock().expect("mutex poisoned"), workers);
+}
+
+fn noop_waker() -> Waker {
+    fn clone(_: *const ()) -> RawWaker {
+        RawWaker::new(std::ptr::null(), &VTABLE)
+    }
+    fn noop(_: *const ()) {}
+    static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
+    let raw = RawWaker::new(std::ptr::null(), &VTABLE);
+    unsafe { Waker::from_raw(raw) }
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut future = Box::pin(future);
+    loop {
+        match Future::poll(Pin::as_mut(&mut future), &mut cx) {
+            Poll::Ready(value) => return value,
+            Poll::Pending => thread::yield_now(),
+        }
+    }
+}
+
+async fn async_add(left: i32, right: i32) -> i32 {
+    left + right
+}
+
+#[test]
+fn hard_async_await_basics() {
+    let result = block_on(async_add(20, 22));
+    assert_eq!(result, 42);
+}
+
+macro_rules! pair_vec {
+    ($($key:expr => $value:expr),* $(,)?) => {{
+        let mut tmp = Vec::new();
+        $(
+            tmp.push(($key, $value));
+        )*
+        tmp
+    }};
+}
+
+#[test]
+fn hard_declarative_macros() {
+    let pairs = pair_vec!("rust" => 1, "cargo" => 2);
+    assert_eq!(pairs, vec![("rust", 1), ("cargo", 2)]);
+}
+
+trait Shape {
+    fn area(&self) -> f64;
+}
+
+struct Rectangle {
+    width: f64,
+    height: f64,
+}
+
+impl Shape for Rectangle {
+    fn area(&self) -> f64 {
+        self.width * self.height
+    }
+}
+
+#[test]
+fn hard_trait_objects() {
+    let shapes: Vec<Box<dyn Shape>> = vec![Box::new(Rectangle {
+        width: 3.0,
+        height: 4.0,
+    })];
+    assert_eq!(shapes[0].area(), 12.0);
+}
+
+#[test]
+fn brutal_unsafe_and_ffi() {
+    let mut value = 41;
+    let ptr = &mut value as *mut i32;
+    unsafe {
+        *ptr += 1;
+    }
+    assert_eq!(value, 42);
+
+    let absolute = unsafe { abs(-42) };
+    assert_eq!(absolute, 42);
+}
+
+#[test]
+fn brutal_atomics_and_memory_ordering() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let mut handles = Vec::new();
+
+    for _ in 0..8 {
+        let counter = Arc::clone(&counter);
+        handles.push(thread::spawn(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }));
+    }
+
+    for handle in handles {
+        handle.join().expect("thread join failed");
+    }
+
+    assert_eq!(counter.load(Ordering::SeqCst), 8);
+}
+
+#[derive(Debug, PartialEq)]
+struct RingBuffer<const N: usize> {
+    data: [u8; N],
+    write_index: usize,
+}
+
+impl<const N: usize> RingBuffer<N> {
+    fn new() -> Self {
+        Self {
+            data: [0; N],
+            write_index: 0,
+        }
+    }
+
+    fn push(&mut self, byte: u8) {
+        self.data[self.write_index % N] = byte;
+        self.write_index += 1;
+    }
+}
+
+#[test]
+fn brutal_const_generics() {
+    let mut rb = RingBuffer::<4>::new();
+    rb.push(10);
+    rb.push(20);
+    rb.push(30);
+    rb.push(40);
+    rb.push(50);
+
+    assert_eq!(rb.data, [50, 20, 30, 40]);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `RUST_PROGRAMMING_TUTORIAL.md` with a complete Rust learning path organized into Easy, Medium, Hard, and Brutal levels
- add a split documentation tree under `docs/rust-features/` with **one Markdown file per concept/feature**, grouped by difficulty:
  - easy (installation, variables, types/control flow, ownership/borrowing/slices, structs/enums/match, modules/collections/Option/Result)
  - medium (generics/traits/lifetimes, iterators/closures, custom errors with `?`, testing/tooling/cfg)
  - hard (smart pointers, thread/channel/mutex concurrency, async/await fundamentals, macros, trait objects)
  - brutal (unsafe Rust, FFI, atomics/memory ordering, const generics)
- include verbose explanations, prerequisites, best practices, pitfalls, and self-contained runnable examples in each concept file
- add `tests/rust_tutorial_examples.rs` with runnable validations for tutorial-backed examples

## Validation
- `cargo test --test rust_tutorial_examples`
- `cargo test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93a2407f-648c-49f4-a1a4-aacd96b0b26c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93a2407f-648c-49f4-a1a4-aacd96b0b26c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

