### PR TITLE
Build Android Pomodoro Clock application

### DIFF
--- a/android-pomodoro-clock/.gitignore
+++ b/android-pomodoro-clock/.gitignore
@@ -14,3 +14,4 @@
 .cxx
 local.properties
 app/release
+app/build/

--- a/android-pomodoro-clock/app/src/main/java/com/example/pomodoro/PomodoroForegroundService.kt
+++ b/android-pomodoro-clock/app/src/main/java/com/example/pomodoro/PomodoroForegroundService.kt
@@ -252,6 +252,7 @@ class PomodoroForegroundService : Service() {
     private fun broadcastState() {
         sendBroadcast(
             Intent(PomodoroServiceContract.ACTION_STATE_CHANGED).apply {
+                setPackage(packageName)
                 putExtra(PomodoroServiceContract.EXTRA_STATE, _state.value)
             }
         )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR builds and fixes the Android Pomodoro Clock application.

## Changes

1. **Bug Fix**: Fixed timer buttons not working (Start/Pause/Reset/Skip)
   - The broadcast from the foreground service to the ViewModel was not being received
   - On Android 13+ (API 33+), receivers registered with `RECEIVER_NOT_EXPORTED` require the broadcast Intent to explicitly set the package name
   - Added `setPackage(packageName)` to the broadcast Intent in `broadcastState()`

2. Added `app/build/` to `.gitignore` to properly exclude build artifacts from version control

## Build Verification

The Android Pomodoro Clock app has been successfully built with:

- **Debug APK**: Generated `app-debug.apk` (8.7 MB)
- **Unit Tests**: All 6 tests passed
  - `PomodoroStateTest`: 2 tests (formattedRemainingTime, progressPercent)
  - `PomodoroTimerEngineTest`: 4 tests (tick decrements, phase transitions, session counting, autostart behavior)

## App Features

The Pomodoro Clock app includes:
- Start/pause/reset timer controls
- Skip to next phase functionality
- Full Pomodoro cycle flow (focus → short break → after 4 focus sessions → long break)
- Configurable durations for focus, short break, and long break
- Completed focus session counter
- Auto-start toggle for next phase
- Progress display with percentage and mm:ss countdown
- Foreground service for reliable background timing
- Persistent notification with quick actions (Start/Pause, Reset, Skip)

## Tech Stack

- Kotlin
- Jetpack Compose (Material 3)
- ViewModel + StateFlow
- Foreground Service for background operation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34f8eb72-0980-4d99-b290-2c5e7d635d8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34f8eb72-0980-4d99-b290-2c5e7d635d8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

