### PR TITLE
Add different colors for focus and break phases

### DIFF
--- a/android-pomodoro-clock/app/src/main/java/com/example/pomodoro/ui/PomodoroApp.kt
+++ b/android-pomodoro-clock/app/src/main/java/com/example/pomodoro/ui/PomodoroApp.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.pomodoro.PomodoroPhase
 import com.example.pomodoro.PomodoroViewModel
+import com.example.pomodoro.ui.theme.phaseColor
 
 @Composable
 fun PomodoroApp(viewModel: PomodoroViewModel) {
@@ -78,11 +79,13 @@ fun PomodoroApp(viewModel: PomodoroViewModel) {
                 Text(
                     text = state.phase.label,
                     style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Medium
+                    fontWeight = FontWeight.Medium,
+                    color = state.phase.phaseColor()
                 )
                 Text(
                     text = state.formattedRemainingTime(),
-                    style = MaterialTheme.typography.displayMedium
+                    style = MaterialTheme.typography.displayMedium,
+                    color = state.phase.phaseColor()
                 )
                 Text(
                     text = "Progress: ${state.progressPercent()}%",

--- a/android-pomodoro-clock/app/src/main/java/com/example/pomodoro/ui/theme/Theme.kt
+++ b/android-pomodoro-clock/app/src/main/java/com/example/pomodoro/ui/theme/Theme.kt
@@ -3,6 +3,12 @@ package com.example.pomodoro.ui.theme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.example.pomodoro.PomodoroPhase
+
+val FocusColor = Color(0xFFFF6B6B)
+val ShortBreakColor = Color(0xFF4ECDC4)
+val LongBreakColor = Color(0xFF5C7AEA)
 
 private val AppColorScheme = darkColorScheme()
 
@@ -14,4 +20,10 @@ fun PomodoroTheme(
         colorScheme = AppColorScheme,
         content = content
     )
+}
+
+fun PomodoroPhase.phaseColor(): Color = when (this) {
+    PomodoroPhase.WORK -> FocusColor
+    PomodoroPhase.SHORT_BREAK -> ShortBreakColor
+    PomodoroPhase.LONG_BREAK -> LongBreakColor
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR adds visual differentiation between focus and break phases in the Pomodoro timer app by applying distinct colors to each phase.

## Changes

### Theme Updates (`Theme.kt`)
- Added phase-specific color constants:
  - **Focus (Work)**: Red (`#FF6B6B`) - A warm, energizing color for productive focus sessions
  - **Short Break**: Teal (`#4ECDC4`) - A refreshing, calming color for short breaks
  - **Long Break**: Blue (`#5C7AEA`) - A deeper, more relaxing color for longer breaks
- Added `phaseColor()` extension function on `PomodoroPhase` enum for easy color lookup

### UI Updates (`PomodoroApp.kt`)
- The phase label ("Focus Time", "Short Break", "Long Break") now displays in the corresponding phase color
- The countdown timer now displays in the corresponding phase color

## Visual Result

Users can now instantly identify which phase they're in at a glance:
- Red tones indicate active focus/work time
- Teal/blue tones indicate break time

The colors align with the existing color definitions in `colors.xml` for consistency.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f24f09a-67f6-4a18-bb67-772fe3343f8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f24f09a-67f6-4a18-bb67-772fe3343f8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

