### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a multi-language programming tutorial monorepo. Each top-level directory is an independent sub-project with its own build system.
+
+### Key services and how to run them
+
+| Language | Directory | Test command | Lint/Format |
+|----------|-----------|-------------|-------------|
+| Python (root) | `/workspace` | `python3 -m pytest tests/ -v` | `flake8 src/ --max-line-length=100`, `black --check src/ tests/` |
+| JavaScript | `javascript/` | `npx vitest run` | `npx prettier --check .` |
+| TypeScript | `typescript/` | `npx vitest run` | `npx prettier --check .` |
+| Go | `go/` | `go test ./...` | `go vet ./...` |
+| Rust | `rust/` | `cargo test` | `cargo clippy` (if installed) |
+| C | `c/` | `make all` (individual binaries build; `make test-all` has pre-existing linker errors) | N/A |
+| Python (sub) | `python/` | `python3 -m pytest python/tests/` (run from workspace root) | `black --check .`, `isort --check .` |
+
+### Non-obvious caveats
+
+- **PATH**: Python user-installed tools (`pytest`, `black`, `flake8`, etc.) are in `~/.local/bin`. This is added to PATH in `~/.bashrc`. If commands are not found, run `export PATH="$HOME/.local/bin:$PATH"`.
+- **Pre-existing test failures**: The root Python tutorial has 5 pre-existing test failures in `test_control_flow.py`, `test_data_structures.py`, and `test_stdlib_examples.py`. These are bugs in the tutorial code/tests, not environment issues.
+- **Pre-existing lint issues**: `flake8` and `black --check` report style issues in the root Python code. These are pre-existing.
+- **rust-tutorial/**: Has a pre-existing `Cargo.toml` parse error (duplicate `[workspace]` key). Use `rust/` (which works) instead.
+- **python/ subdirectory**: The `test_async_sum` test requires `pytest-asyncio` which is not in its `requirements.txt`. The other 2 tests pass.
+- **TypeScript build**: `tsc` fails due to missing `@types/node`, but `vitest run` works fine for tests.
+- **No Docker/databases needed**: This is a pure tutorial repo with no services to start.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development environment instructions for this multi-language tutorial monorepo.

### What's included

- Quick-reference table for running tests and lint/format checks across all major language sub-projects (Python, JavaScript, TypeScript, Go, Rust, C)
- Non-obvious caveats discovered during environment setup (PATH issues, pre-existing test failures, broken sub-projects)

### Environment verification

All major sub-projects were tested:

| Language | Tests | Lint | Status |
|----------|-------|------|--------|
| Python (root) | 68 passed, 5 failed (pre-existing) | flake8 runs (pre-existing warnings) | Working |
| JavaScript | 1 passed | prettier runs | Working |
| TypeScript | 1 passed | prettier runs | Working |
| Go | 1 passed | go vet clean | Working |
| Rust | 16 passed | N/A | Working |
| C | Builds (individual) | N/A | Working (test runner has pre-existing linker issues) |

[env_verification.log](https://cursor.com/agents/bc-e64d02d8-3853-42c7-8cf5-4a49ac03687a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenv_verification.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e64d02d8-3853-42c7-8cf5-4a49ac03687a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e64d02d8-3853-42c7-8cf5-4a49ac03687a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

